### PR TITLE
Fix incorrect URL in Simple deprecation notice

### DIFF
--- a/content/guides/simple.md
+++ b/content/guides/simple.md
@@ -5,7 +5,7 @@ description: How to use SIP.js Simple API to make and receive a call
 
 # Disclaimer
 
-SIP.js Simple is considered deprecated and we will no longer support it. You should consider upgrading to the [Simple User](./simple-user) on the latest SIP.js Version.
+SIP.js Simple is considered deprecated and we will no longer support it. You should consider upgrading to the [Simple User](/simple-user) on the latest SIP.js Version.
 
 # SIP.js Simple Guide
 


### PR DESCRIPTION
The deprecation disclaimer on `Simple` is linking to an invalid page (resolves to https://sipjs.com/guides/simple/simple-user). This PR changes the link so that it links to a valid page.